### PR TITLE
Add definition file for AboutLibraries

### DIFF
--- a/openpgp-api/src/main/res/values/aboutlibraries_strings.xml
+++ b/openpgp-api/src/main/res/values/aboutlibraries_strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="define_OpenPGPAPILibrary"></string>
+    <string name="library_OpenPGPAPILibrary_author">Dominik Schürmann</string>
+    <string name="library_OpenPGPAPILibrary_authorWebsite">https://www.schuermann.eu/</string>
+    <string name="library_OpenPGPAPILibrary_libraryName">OpenPGP API library</string>
+    <string name="library_OpenPGPAPILibrary_libraryDescription">The OpenPGP API provides methods to
+        execute OpenPGP operations, such as sign, encrypt, decrypt, verify, and more without user
+        interaction from background threads. This is done by connecting your client application to a
+        remote service provided by OpenKeychain or other OpenPGP providers.</string>
+    <string name="library_OpenPGPAPILibrary_libraryVersion">12</string>
+    <string name="library_OpenPGPAPILibrary_libraryWebsite">https://www.openkeychain.org/</string>
+    <string name="library_OpenPGPAPILibrary_licenseId">apache_2_0</string>
+    <string name="library_OpenPGPAPILibrary_isOpenSource">true</string>
+    <string name="library_OpenPGPAPILibrary_repositoryLink">https://github.com/open-keychain/openpgp-api/</string>
+</resources>


### PR DESCRIPTION
Most apps feature a section that lists all used (open-source) libraries. A very simple way to do that is to use [AboutLibraries](https://github.com/mikepenz/AboutLibraries), which tries to automatically pick up all used libraries and list them. To do that a simple resource file containing all the necessary information has to be added to the library, which is done in this PR.

If, for some reason, you don't want this in your lib then I can also make a PR to [AboutLibraries](https://github.com/mikepenz/AboutLibraries) to add it to it's internal database. But the preferred way is to add the definition to the upstream project. 