### PR TITLE
Accept emails without a TLD during identifier parsing

### DIFF
--- a/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpUtils.java
+++ b/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpUtils.java
@@ -75,7 +75,7 @@ public class OpenPgpUtils {
 
     private static final Pattern USER_ID_PATTERN = Pattern.compile("^(.*?)(?: \\((.*)\\))?(?: <(.*)>)?$");
 
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^<?\"?([^<>\"]*@[^<>\"]*\\.[^<>\"]*)\"?>?$");
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^<?\"?([^<>\"]*@[^<>\"]*[.]?[^<>\"]*)\"?>?$");
 
     /**
      * Splits userId string into naming part, email part, and comment part.


### PR DESCRIPTION
GPG is way too lenient about what an email is, and OpenKeychain seems to be fine with a missing TLD as well.

Fixes https://github.com/open-keychain/open-keychain/issues/2579
