### PR TITLE
Update README since dependency current artifact cannot be resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ allprojects {                                                                   
 }                                                                                                                                                                                                                  
                                                                                                          
 dependencies {
-        implementation 'com.github.open-keychain:openpgp-api:v10'
+        implementation 'com.github.open-keychain:openpgp-api:v11'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Thus, you are allowed to also use it in closed source applications as long as yo
 Add this to your build.gradle:
 
 ```gradle
-repositories {
-    maven { url 'https://jitpack.io' }
-}
-
+allprojects {                                                                                                                                                                                                              repositories {                                                                                   
+                ...                            
+                maven { url 'https://jitpack.io' }                                                                                                                                                                         }        
+}                                                                                                                                                                                                                  
+                                                                                                         
 dependencies {
-    implementation 'com.github.open-keychain.open-keychain:openpgp-api:v5.7.1'
+        implementation 'com.github.open-keychain:openpgp-api:v10'
 }
 ```
 


### PR DESCRIPTION
Hi,

Unless I am mistaken, given dependency path is wrong in README. After some researches, I found the right one looking for it at https://jitpack.io/#open-keychain/openpgp-api/v11.

Thanks !